### PR TITLE
fix: UnicodeDecodeError

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ def get_file_list():
     url = 'https://down.52pojie.cn/list.js'
     headers = {
         'Host': 'down.52pojie.cn',
-        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'
+        'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:45.0) Gecko/20100101 Firefox/45.0'
     }
     res = requests.get(url, headers = headers)
     data = res.content

--- a/main.py
+++ b/main.py
@@ -9,6 +9,8 @@ try:
 except:
     import json
 
+reload(sys)
+sys.setdefaultencoding('utf8')    
 
 def save_file(path, data):
     f = file(path, 'w')


### PR DESCRIPTION
操作系统：Kali GNU/Linux Rolling 64-bit
问题描述：脚本在处理中文件名出现编码错误